### PR TITLE
Add #include <cstdint> needed for compilation on recent gcc version

### DIFF
--- a/library/SteamworksPy.cpp
+++ b/library/SteamworksPy.cpp
@@ -21,6 +21,7 @@
 
 #include <iostream>
 #include <string>
+#include <cstdint>
 
 //-----------------------------------------------
 // Definitions


### PR DESCRIPTION
Hello its a paatch needed for flatpak compatibility on recent gcc version